### PR TITLE
[v0.2.2]: Add test case for when an experiment's hashAttribute is an …

### DIFF
--- a/lib/src/Evaluator/experiment_evaluator.dart
+++ b/lib/src/Evaluator/experiment_evaluator.dart
@@ -42,8 +42,9 @@ class GBExperimentEvaluator {
 
     // Get the user hash attribute and value (context.attributes[experiment.hashAttribute || "id"])
     // and if empty, return immediately (not in experiment, variationId 0)
-    final attributeValue =
-        context.attributes?[experiment.hashAttribute ?? Constant.idAttribute];
+    final attributeValue = context
+        .attributes?[experiment.hashAttribute ?? Constant.idAttribute]
+        ?.toString();
     if (attributeValue == null || attributeValue.toString().isEmpty) {
       return _getExperimentResult(
         experiment: experiment,
@@ -100,7 +101,7 @@ class GBExperimentEvaluator {
                 .toList()
             : []);
 
-    final hash = GBUtils.hash(attributeValue + experiment.key);
+    final hash = GBUtils.hash(attributeValue + (experiment.key ?? ''));
     final assigned = const GBUtils().chooseVariation(hash, bucketRange);
     // If not assigned a variation (assigned === -1), return immediately (not in experiment, variationId 0)
     if (assigned == -1) {

--- a/lib/src/Evaluator/feature_evaluator.dart
+++ b/lib/src/Evaluator/feature_evaluator.dart
@@ -38,7 +38,7 @@ class GBFeatureEvaluator {
           /// If rule.coverage is set
           if (rule.coverage != null) {
             final key = rule.hashAttribute ?? Constant.idAttribute;
-            final attributeValue = context.attributes?[key] as String? ?? '';
+            final attributeValue = context.attributes?[key].toString() ?? '';
 
             if (attributeValue.isEmpty) {
               continue;

--- a/test/Helper/gb_test_helper.dart
+++ b/test/Helper/gb_test_helper.dart
@@ -98,6 +98,7 @@ class GBContextTest {
     this.enabled = true,
     this.forcedVariations,
   });
+
   dynamic attributes;
   bool qaMode;
   bool enabled;
@@ -141,6 +142,6 @@ class GBExperimentResultTest {
         inExperiment: map['inExperiment'],
         variationId: map['variationId'],
         hashAttribute: map['hashAttribute'],
-        hashValue: map['hashValue'],
+        hashValue: map['hashValue']?.toString(),
       );
 }

--- a/test/test_cases/test_case.dart
+++ b/test/test_cases/test_case.dart
@@ -1748,6 +1748,32 @@ const String gbTestCases = r'''
           }
         ],
         [
+            "force rule - coverage with integer hash attribute",
+            {
+                "attributes": {
+                    "id": 3
+                },
+                "features": {
+                    "feature": {
+                        "defaultValue": 2,
+                        "rules": [
+                            {
+                                "force": 1,
+                                "coverage": 0.5
+                            }
+                        ]
+                    }
+                }
+            },
+            "feature",
+            {
+                "value": 1,
+                "on": true,
+                "off": false,
+                "source": "force"
+            }
+        ],
+        [
           "force rules - coverage excluded",
           {
             "attributes": {
@@ -2277,6 +2303,44 @@ const String gbTestCases = r'''
             "on": true,
             "off": false,
             "source": "force"
+          }
+        ],
+        [
+          "handles integer hashAttribute",
+          {
+            "attributes": { "id": 123 },
+            "features": {
+              "feature": {
+                "defaultValue": 0,
+                "rules": [
+                  {
+                    "variations": [0, 1]
+                  }
+                ]
+              }
+            }
+          },
+          "feature",
+          {
+            "value": 1,
+            "on": true,
+            "off": false,
+            "source": "experiment",
+            "experiment": {
+              "key": "feature",
+              "variations": [0, 1]
+            },
+            "experimentResult": {
+              "featureId": "feature",
+              "hashAttribute": "id",
+              "hashValue": 123,
+              "hashUsed": true,
+              "inExperiment": true,
+              "value": 1,
+              "variationId": 1,
+              "key": "1",
+              "bucket": 0.863
+            }
           }
         ],
         [


### PR DESCRIPTION
…integer

- Convert attributeValue to String
- Add test case "force rules - coverage excluded"
- Add test case "handles integer hashAttribute"